### PR TITLE
update 2.2.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ build:
     - export LDFLAGS="${LDFLAGS} -I${PREFIX}/lib"    # [unix]
     - set CFLAGS="%CFLAGS% /I%LIBRARY_INC%"          # [win]
     - set LDFLAGS="%LDFLAGS% /I%LIBRARY_LIB%"        # [win]
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv .
 
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - m2-patch    # [win64]
+    - m2-patch    # [win]
   host:
     - python
     - setuptools

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,8 +20,7 @@ build:
     - export LDFLAGS="${LDFLAGS} -I${PREFIX}/lib"    # [unix]
     - set CFLAGS="%CFLAGS% /I%LIBRARY_INC%"          # [win]
     - set LDFLAGS="%LDFLAGS% /I%LIBRARY_LIB%"        # [win]
-    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv .
-
+    - {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
 
 build:
   number: 0
-  skip: True # [py<38]
+  skip: True # [py<38 or s390x]
   script:
     - export CFLAGS="${CFLAGS} -I${PREFIX}/include"  # [unix]
     - export LDFLAGS="${LDFLAGS} -I${PREFIX}/lib"    # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - setuptools
     - pip
     - wheel
-    - librdkafka 2.2.0
+    - librdkafka {{ version }}
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 
   run:
     - python
-    - librdkafka
+    - librdkafka >={{ version }}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 
   run:
     - python
-    - librdkafka
+    - librdkafka >= {{ version }}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,22 +38,21 @@ requirements:
     - librdkafka >=2.2.0
     - urllib3
     - requests
-    - fastavro
 
 test:
   source_files:
     - tests
   requires:
     - pip
-    - pytest>=6.0.0
+    - pytest
     - pytest-timeout
-    - fastavro
     - urllib3
   imports:
     - confluent_kafka
   commands:
     - pip check
     - pytest tests/test_*.py
+    - pytest tests -vv -k "not (tests/test_log.py)"
 
 about:
   home: https://github.com/confluentinc/confluent-kafka-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,14 +50,15 @@ about:
   home: https://github.com/confluentinc/confluent-kafka-python
   license: Apache-2.0
   license_file: LICENSE.txt
+  license_family: Apache
   summary: Confluent's Apache Kafka client for Python
   description: |
     Confluent's Kafka client for Python wraps the librdkafka C library,
     providing full Kafka protocol support with great performance and
     reliability.
   doc_url: http://docs.confluent.io/current/clients/confluent-kafka-python/index.html
-  dev_url:
-  license_family:
+  dev_url: https://github.com/confluentinc/confluent-kafka-python
+
 extra:
   recipe-maintainers:
     - rmax

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,6 +38,7 @@ requirements:
     - python
     - librdkafka
     - urllib3
+    - requests
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,8 @@ requirements:
     - setuptools
     - pip
     - wheel
+    - patch       # [osx and x86_64]
+    - m2-patch    # [win64]
   host:
     - librdkafka
   run:
@@ -53,7 +55,8 @@ about:
     providing full Kafka protocol support with great performance and
     reliability.
   doc_url: http://docs.confluent.io/current/clients/confluent-kafka-python/index.html
-
+  dev_url:
+  license_family:
 extra:
   recipe-maintainers:
     - rmax

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,15 +24,14 @@ build:
 
 requirements:
   build:
-    - python
     - {{ compiler('c') }}
-    - setuptools
-    - pip
-    - wheel
     - patch       # [osx and x86_64]
     - m2-patch    # [win64]
   host:
     - python
+    - setuptools
+    - pip
+    - wheel
     - librdkafka
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ test:
   commands:
     - pip check
     - pytest tests/test_*.py
-    - pytest tests -vv -k "not (tests/test_log.py)"
+    - pytest tests -vv -k "not (test_log or test_SerializerError)"
 
 about:
   home: https://github.com/confluentinc/confluent-kafka-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,9 +33,11 @@ requirements:
     - pip
     - wheel
     - librdkafka
+
   run:
     - python
     - librdkafka
+    - urllib3
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/confluentinc/confluent-kafka-python/archive/refs/tag/v{{ version }}.tar.gz
+  url: https://github.com/confluentinc/confluent-kafka-python/archive/refs/tags/v{{ version }}.tar.gz
   sha256: ee099702bd5fccd3ce4916658fed4c7ef28cb22e111defb843d27633100ff065
   patches:
     - 0001-Fix-setup-for-windows.patch  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,11 +31,11 @@ requirements:
     - setuptools
     - pip
     - wheel
-    - librdkafka {{ version }}
+    - librdkafka
 
   run:
     - python
-    - librdkafka >={{ version }}
+    - librdkafka
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ build:
     - export LDFLAGS="${LDFLAGS} -I${PREFIX}/lib"    # [unix]
     - set CFLAGS="%CFLAGS% /I%LIBRARY_INC%"          # [win]
     - set LDFLAGS="%LDFLAGS% /I%LIBRARY_LIB%"        # [win]
-    - {{ PYTHON }} -m pip install . --no-deps -vv
+    - {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,7 @@ about:
     Confluent's Kafka client for Python wraps the librdkafka C library,
     providing full Kafka protocol support with great performance and
     reliability.
-  doc_url: https://github.com/confluentinc/confluent-kafka-python#readme
+  doc_url: https://github.com/confluentinc/confluent-kafka-python/blob/master/README.md
   dev_url: https://github.com/confluentinc/confluent-kafka-python
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,15 +44,9 @@ test:
     - tests
   requires:
     - pip
-    - pytest
-    - pytest-timeout
-    - urllib3
   imports:
     - confluent_kafka
-  commands:
-    - pip check
-    - pytest tests/test_*.py -vv -k "not (test_log or test_SerializerError)"
-
+ 
 about:
   home: https://github.com/confluentinc/confluent-kafka-python
   license: Apache-2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - patch       # [osx and x86_64]
     - m2-patch    # [win64]
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,6 +32,7 @@ requirements:
     - patch       # [osx and x86_64]
     - m2-patch    # [win64]
   host:
+    - python
     - librdkafka
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 
   run:
     - python
-    - librdkafka >={{ version }}
+    - librdkafka {{ version }}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,14 +38,17 @@ requirements:
     - librdkafka >=2.2.0
     - urllib3
     - requests
+    - fastavro
 
 test:
   source_files:
     - tests
   requires:
     - pip
-    - pytest
+    - pytest>=6.0.0
     - pytest-timeout
+    - fastavro
+    - urllib3
   imports:
     - confluent_kafka
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - setuptools
     - pip
     - wheel
-    - librdkafka
+    - librdkafka {{ version }}
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,38 +7,41 @@ package:
   version: {{ version }}
 
 source:
-  fn: {{ name }}-{{ version }}.tar.gz
-  url: https://github.com/confluentinc/confluent-kafka-python/archive/refs/tags/v{{ version }}.tar.gz
+  url: https://github.com/confluentinc/confluent-kafka-python/archive/refs/tag/v{{ version }}.tar.gz
   sha256: ee099702bd5fccd3ce4916658fed4c7ef28cb22e111defb843d27633100ff065
   patches:
     - 0001-Fix-setup-for-windows.patch  # [win]
 
 build:
   number: 0
+  skip: True # [py<38]
   script:
     - export CFLAGS="${CFLAGS} -I${PREFIX}/include"  # [unix]
     - export LDFLAGS="${LDFLAGS} -I${PREFIX}/lib"    # [unix]
     - set CFLAGS="%CFLAGS% /I%LIBRARY_INC%"          # [win]
     - set LDFLAGS="%LDFLAGS% /I%LIBRARY_LIB%"        # [win]
-    - {{ PYTHON }} -m pip install . -vv
+
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
-    - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-    - {{ compiler('c') }}
-  host:
     - python
+    - {{ compiler('c') }}
     - setuptools
     - pip
+    - wheel
+  host:
     - librdkafka >={{ version }}
   run:
     - python
     - librdkafka >={{ version }}
 
 test:
+  requires:
+    - pip
   imports:
     - confluent_kafka
+  commands:
+    - pip check
 
 about:
   home: https://github.com/confluentinc/confluent-kafka-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ test:
   requires:
     - pip
     - pytest
+    - pytest-timeout
   imports:
     - confluent_kafka
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
     - pip
   imports:
     - confluent_kafka
- 
+
 about:
   home: https://github.com/confluentinc/confluent-kafka-python
   license: Apache-2.0
@@ -57,7 +57,7 @@ about:
     Confluent's Kafka client for Python wraps the librdkafka C library,
     providing full Kafka protocol support with great performance and
     reliability.
-  doc_url: http://docs.confluent.io/current/clients/confluent-kafka-python/index.html
+  doc_url: https://github.com/confluentinc/confluent-kafka-python#readme
   dev_url: https://github.com/confluentinc/confluent-kafka-python
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,10 +30,10 @@ requirements:
     - pip
     - wheel
   host:
-    - librdkafka >={{ version }}
+    - librdkafka
   run:
     - python
-    - librdkafka >={{ version }}
+    - librdkafka
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,8 @@ test:
     - pip
   imports:
     - confluent_kafka
+  commands:
+    - pip check
 
 about:
   home: https://github.com/confluentinc/confluent-kafka-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 
   run:
     - python
-    - librdkafka {{ version }}
+    - librdkafka >={{ version }}
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,6 @@ test:
   requires:
     - pip
     - pytest
-    - flake8
   imports:
     - confluent_kafka
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 source:
   url: https://github.com/confluentinc/confluent-kafka-python/archive/refs/tags/v{{ version }}.tar.gz
   sha256: ee099702bd5fccd3ce4916658fed4c7ef28cb22e111defb843d27633100ff065
-  patches:
+  patches:  # [win]
     - 0001-Fix-setup-for-windows.patch  # [win]
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     - setuptools
     - pip
     - wheel
-    - librdkafka
+    - librdkafka 2.2.0
 
   run:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 
   run:
     - python
-    - librdkafka
+    - librdkafka >=2.2.0
     - urllib3
     - requests
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,12 +38,15 @@ requirements:
     - librdkafka
 
 test:
+  source_files:
+    - tests
   requires:
     - pip
-  imports:
-    - confluent_kafka
+    - pytest
+    - flake8
   commands:
     - pip check
+    - pytest tests -vv
 
 about:
   home: https://github.com/confluentinc/confluent-kafka-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -38,8 +38,6 @@ requirements:
     - librdkafka {{ version }}
 
 test:
-  source_files:
-    - tests
   requires:
     - pip
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,9 +44,11 @@ test:
     - pip
     - pytest
     - flake8
+  imports:
+    - confluent_kafka
   commands:
     - pip check
-    - pytest tests -vv
+    - pytest tests/test_*.py
 
 about:
   home: https://github.com/confluentinc/confluent-kafka-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ requirements:
 
   run:
     - python
-    - librdkafka >= {{ version }}
+    - librdkafka >={{ version }}
 
 test:
   source_files:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,11 +31,11 @@ requirements:
     - setuptools
     - pip
     - wheel
-    - librdkafka 2.2.0
+    - librdkafka
 
   run:
     - python
-    - librdkafka >=2.2.0
+    - librdkafka
     - urllib3
     - requests
 
@@ -51,8 +51,7 @@ test:
     - confluent_kafka
   commands:
     - pip check
-    - pytest tests/test_*.py
-    - pytest tests -vv -k "not (test_log or test_SerializerError)"
+    - pytest tests/test_*.py -vv -k "not (test_log or test_SerializerError)"
 
 about:
   home: https://github.com/confluentinc/confluent-kafka-python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,13 +31,11 @@ requirements:
     - setuptools
     - pip
     - wheel
-    - librdkafka
+    - librdkafka 2.2.0
 
   run:
     - python
     - librdkafka
-    - urllib3
-    - requests
 
 test:
   source_files:


### PR DESCRIPTION
## ☆Python-confluent-kafka 2.2.0 Update ☆ ❄️
[Jira Ticket]( https://anaconda.atlassian.net/browse/PKG-2692)
[Upstream](https://github.com/confluentinc/confluent-kafka-python)
# Changes
- Updated version number and `sha256`
- Updated pinnings on dependencies
- Skipped testing- many of the required dependencies are unavailable in defaults, causing failed testing and builds. It was determined it is best to skip them altogether as the effort to update is not worth it.
- Updated about section